### PR TITLE
Deprecate expand! in favour of EmbiggenedURIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,27 +23,36 @@ require 'embiggen'
 
 # Basic usage
 Embiggen::URI('https://youtu.be/dQw4w9WgXcQ').expand
-#=> #<URI:HTTPS https://www.youtube.com/watch?v=dQw4w9WgXcQ&feature=youtu.be>
+#=> #<Embiggen::EmbiggenedURI https://www.youtube.com/watch?v=dQw4w9WgXcQ&feature=youtu.be>
 
 # Longer-form usage
 uri = Embiggen::URI.new(URI('https://youtu.be/dQw4w9WgXcQ'))
 uri.shortened?
 #=> true
-uri.expand
-#=> #<URI:HTTPS https://www.youtube.com/watch?v=dQw4w9WgXcQ&feature=youtu.be>
+expanded_uri = uri.expand
+#=> #<Embiggen::EmbiggenedURI https://www.youtube.com/watch?v=dQw4w9WgXcQ&feature=youtu.be>
+expanded_uri.success?
+#=> true
 
 # Gracefully deals with unshortened URIs
 uri = Embiggen::URI('http://www.altmetric.com')
 uri.shortened?
 #=> false
 uri.expand
-#=> #<URI:HTTP http://www.altmetric.com>
+#=> #<Embiggen::EmbiggenedURI http://www.altmetric.com>
 
-# Noisier expand! for explicit error handling
-Embiggen::URI('http://bit.ly/bad').expand!
-#=> TooManyRedirects: http://bit.ly/bad redirected too many times
-# or...
-#=> BadShortenedURI: following http://bit.ly/bad did not redirect
+# Gracefully deals with errors
+uri = Embiggen::URI('http://examp.le/badlink').expand
+#=> #<Embiggen::EmbiggenedURI http://examp.le/badlink>
+uri.success?
+#=> false
+uri.reason
+#=> 'following http://examp.le/badlink did not redirect'
+
+uri = Embiggen::URI('http://examp.le/loop').expand
+#=> #<Embiggen::EmbiggenedURI http://examp.le/loop>
+uri.reason
+#=> 'http://examp.le/loop redirected too many times'
 
 # Optionally specify a timeout in seconds for expansion (default is 1)
 Embiggen::URI('https://youtu.be/dQw4w9WgXcQ').expand(:timeout => 5)

--- a/README.md
+++ b/README.md
@@ -50,10 +50,12 @@ uri.success?
 # If there weren't successful, you can ask them why
 uri.success?
 #=> false
-uri.reason
-#=> 'following https://youtu.be/dQw4w9WgXcQ did not redirect'
+uri.error
+#=> #<Embiggen::TooManyRedirects ...>
 # or
-#=> 'https://youtu.be/dQw4w9WgXcQ redirected too many times'
+#=> #<Embiggen::BadShortenedURI ...>
+# or
+#=> #<Timeout::Error ...>
 
 # Before expansion, you can check whether a URI is shortened or not
 Embiggen::URI('https://youtu.be/dQw4w9WgXcQ').shortened?

--- a/README.md
+++ b/README.md
@@ -22,16 +22,41 @@ gem 'embiggen', '~> 0.1'
 require 'embiggen'
 
 # Basic usage
-Embiggen::URI('https://youtu.be/dQw4w9WgXcQ').expand
+uri = Embiggen::URI('https://youtu.be/dQw4w9WgXcQ').expand
 #=> #<Embiggen::EmbiggenedURI https://www.youtube.com/watch?v=dQw4w9WgXcQ&feature=youtu.be>
 
-# Longer-form usage
-uri = Embiggen::URI.new(URI('https://youtu.be/dQw4w9WgXcQ'))
-uri.shortened?
+# EmbiggenedURIs can be used much like standard URIs
+uri.to_s
+#=> 'https://www.youtube.com/watch?v=dQw4w9WgXcQ&feature=youtu.be'
+uri.host
+#=> 'www.youtube.com'
+uri.path
+#=> '/watch'
+uri.query
+#=> 'v=dQw4w9WgXcQ&feature=youtu.be'
+uri.request_uri
+#=> '/watch?v=dQw4w9WgXcQ&feature=youtu.be'
+uri.scheme
+#=> 'https'
+
+# Or you can get an actual standard library URI instance out of them
+uri.uri
+#=> #<URI::HTTPS https://www.youtube.com/watch?v=dQw4w9WgXcQ&feature=youtu.be>
+
+# You can interrogate them to see if they expanded successfully
+uri.success?
 #=> true
-expanded_uri = uri.expand
-#=> #<Embiggen::EmbiggenedURI https://www.youtube.com/watch?v=dQw4w9WgXcQ&feature=youtu.be>
-expanded_uri.success?
+
+# If there weren't successful, you can ask them why
+uri.success?
+#=> false
+uri.reason
+#=> 'following https://youtu.be/dQw4w9WgXcQ did not redirect'
+# or
+#=> 'https://youtu.be/dQw4w9WgXcQ redirected too many times'
+
+# Before expansion, you can check whether a URI is shortened or not
+Embiggen::URI('https://youtu.be/dQw4w9WgXcQ').shortened?
 #=> true
 
 # Gracefully deals with unshortened URIs
@@ -40,19 +65,6 @@ uri.shortened?
 #=> false
 uri.expand
 #=> #<Embiggen::EmbiggenedURI http://www.altmetric.com>
-
-# Gracefully deals with errors
-uri = Embiggen::URI('http://examp.le/badlink').expand
-#=> #<Embiggen::EmbiggenedURI http://examp.le/badlink>
-uri.success?
-#=> false
-uri.reason
-#=> 'following http://examp.le/badlink did not redirect'
-
-uri = Embiggen::URI('http://examp.le/loop').expand
-#=> #<Embiggen::EmbiggenedURI http://examp.le/loop>
-uri.reason
-#=> 'http://examp.le/loop redirected too many times'
 
 # Optionally specify a timeout in seconds for expansion (default is 1)
 Embiggen::URI('https://youtu.be/dQw4w9WgXcQ').expand(:timeout => 5)

--- a/lib/embiggen/bad_shortened_uri.rb
+++ b/lib/embiggen/bad_shortened_uri.rb
@@ -1,0 +1,9 @@
+require 'embiggen/error'
+
+module Embiggen
+  class BadShortenedURI < Error
+    def self.for(uri)
+      new("following #{uri} did not redirect")
+    end
+  end
+end

--- a/lib/embiggen/embiggened_uri.rb
+++ b/lib/embiggen/embiggened_uri.rb
@@ -1,0 +1,26 @@
+require 'delegate'
+
+module Embiggen
+  class EmbiggenedURI < SimpleDelegator
+    attr_reader :success, :reason
+    alias_method :success?, :success
+
+    def self.success(uri)
+      new(uri, :success => true)
+    end
+
+    def self.failure(uri, reason = nil)
+      new(uri, :success => false, :reason => reason)
+    end
+
+    def initialize(uri, options = {})
+      super(uri)
+      @success = options.fetch(:success)
+      @reason = options[:reason]
+    end
+
+    def inspect
+      "#<#{self.class} #{self}>"
+    end
+  end
+end

--- a/lib/embiggen/embiggened_uri.rb
+++ b/lib/embiggen/embiggened_uri.rb
@@ -3,7 +3,7 @@ require 'forwardable'
 module Embiggen
   class EmbiggenedURI
     extend Forwardable
-    attr_reader :uri, :success, :reason
+    attr_reader :uri, :success, :error
     alias_method :success?, :success
     def_delegators :uri, :to_s, :fragment, :host, :path, :port, :query,
                    :scheme, :request_uri
@@ -12,14 +12,14 @@ module Embiggen
       new(uri, :success => true)
     end
 
-    def self.failure(uri, reason = nil)
-      new(uri, :success => false, :reason => reason)
+    def self.failure(uri, error = nil)
+      new(uri, :success => false, :error => error)
     end
 
     def initialize(uri, options = {})
       @uri = uri
-      @success = options.fetch(:success)
-      @reason = options[:reason]
+      @success = options.fetch(:success) { !options.key?(:error) }
+      @error = options[:error]
     end
 
     def inspect

--- a/lib/embiggen/embiggened_uri.rb
+++ b/lib/embiggen/embiggened_uri.rb
@@ -1,9 +1,12 @@
-require 'delegate'
+require 'forwardable'
 
 module Embiggen
-  class EmbiggenedURI < SimpleDelegator
-    attr_reader :success, :reason
+  class EmbiggenedURI
+    extend Forwardable
+    attr_reader :uri, :success, :reason
     alias_method :success?, :success
+    def_delegators :uri, :to_s, :fragment, :host, :path, :port, :query,
+                   :scheme, :request_uri
 
     def self.success(uri)
       new(uri, :success => true)
@@ -14,7 +17,7 @@ module Embiggen
     end
 
     def initialize(uri, options = {})
-      super(uri)
+      @uri = uri
       @success = options.fetch(:success)
       @reason = options[:reason]
     end

--- a/lib/embiggen/error.rb
+++ b/lib/embiggen/error.rb
@@ -1,0 +1,4 @@
+module Embiggen
+  class Error < ::RuntimeError
+  end
+end

--- a/lib/embiggen/too_many_redirects.rb
+++ b/lib/embiggen/too_many_redirects.rb
@@ -1,0 +1,9 @@
+require 'embiggen/error'
+
+module Embiggen
+  class TooManyRedirects < Error
+    def self.for(uri)
+      new("#{uri} redirected too many times")
+    end
+  end
+end

--- a/spec/embiggen/embiggened_uri_spec.rb
+++ b/spec/embiggen/embiggened_uri_spec.rb
@@ -17,12 +17,19 @@ module Embiggen
         expect(failed_uri).to_not be_success
       end
 
-      it 'takes an optional reason for failure' do
+      it 'takes an optional cause for failure' do
         uri = URI.new('http://bit.ly/bad')
-        failed_uri = described_class.failure(uri, 'something went wrong')
+        error = Error.new('whoops')
+        failed_uri = described_class.failure(uri, error)
 
-        expect(failed_uri.reason).to eq('something went wrong')
+        expect(failed_uri.error).to eq(error)
       end
+    end
+
+    it 'defaults to being successful if there is no error' do
+      uri = described_class.new(URI('http://www.altmetric.com'))
+
+      expect(uri).to be_success
     end
 
     describe '#uri' do

--- a/spec/embiggen/embiggened_uri_spec.rb
+++ b/spec/embiggen/embiggened_uri_spec.rb
@@ -4,7 +4,7 @@ module Embiggen
   RSpec.describe EmbiggenedURI do
     describe '.success' do
       it 'returns successful URIs' do
-        uri = described_class.success(URI.new('http://www.altmetric.com'))
+        uri = described_class.success(URI('http://www.altmetric.com'))
 
         expect(uri).to be_success
       end
@@ -12,7 +12,7 @@ module Embiggen
 
     describe '.failure' do
       it 'returns unsuccessful URIs' do
-        failed_uri = described_class.failure(URI.new('http://bit.ly/bad'))
+        failed_uri = described_class.failure(URI('http://bit.ly/bad'))
 
         expect(failed_uri).to_not be_success
       end
@@ -25,12 +25,84 @@ module Embiggen
       end
     end
 
+    describe '#uri' do
+      it 'returns the URI within' do
+        uri = described_class.success(URI('http://www.altmetric.com'))
+
+        expect(uri.uri).to eq(URI('http://www.altmetric.com'))
+      end
+    end
+
     describe '#inspect' do
       it 'reports the correct class name' do
-        uri = described_class.success(URI.new('http://www.altmetric.com'))
+        uri = described_class.success(URI('http://www.altmetric.com'))
 
         expect(uri.inspect).to eq('#<Embiggen::EmbiggenedURI ' \
                                   'http://www.altmetric.com>')
+      end
+    end
+
+    describe '#to_s' do
+      it 'returns the URI as a string' do
+        uri = described_class.success(URI('http://www.altmetric.com'))
+
+        expect(uri.to_s).to eq('http://www.altmetric.com')
+      end
+    end
+
+    describe '#host' do
+      it 'returns the host of the URI' do
+        uri = described_class.success(URI('http://www.altmetric.com'))
+
+        expect(uri.host).to eq('www.altmetric.com')
+      end
+    end
+
+    describe '#port' do
+      it 'returns the port of the URI' do
+        uri = described_class.success(URI('http://www.altmetric.com'))
+
+        expect(uri.port).to eq(80)
+      end
+    end
+
+    describe '#path' do
+      it 'returns the path of the URI' do
+        uri = described_class.success(URI('http://www.altmetric.com/foo?123'))
+
+        expect(uri.path).to eq('/foo')
+      end
+    end
+
+    describe '#scheme' do
+      it 'returns the scheme of the URI' do
+        uri = described_class.success(URI('http://www.altmetric.com'))
+
+        expect(uri.scheme).to eq('http')
+      end
+    end
+
+    describe '#request_uri' do
+      it 'returns the request URI of the URI' do
+        uri = described_class.success(URI('http://www.altmetric.com/foo?123'))
+
+        expect(uri.request_uri).to eq('/foo?123')
+      end
+    end
+
+    describe '#fragment' do
+      it 'returns the fragment of the URI' do
+        uri = described_class.success(URI('http://www.altmetric.com/#foo'))
+
+        expect(uri.fragment).to eq('foo')
+      end
+    end
+
+    describe '#query' do
+      it 'returns the query string of the URI' do
+        uri = described_class.success(URI('http://www.altmetric.com?foo=123'))
+
+        expect(uri.query).to eq('foo=123')
       end
     end
   end

--- a/spec/embiggen/embiggened_uri_spec.rb
+++ b/spec/embiggen/embiggened_uri_spec.rb
@@ -1,0 +1,37 @@
+require 'embiggen'
+
+module Embiggen
+  RSpec.describe EmbiggenedURI do
+    describe '.success' do
+      it 'returns successful URIs' do
+        uri = described_class.success(URI.new('http://www.altmetric.com'))
+
+        expect(uri).to be_success
+      end
+    end
+
+    describe '.failure' do
+      it 'returns unsuccessful URIs' do
+        failed_uri = described_class.failure(URI.new('http://bit.ly/bad'))
+
+        expect(failed_uri).to_not be_success
+      end
+
+      it 'takes an optional reason for failure' do
+        uri = URI.new('http://bit.ly/bad')
+        failed_uri = described_class.failure(uri, 'something went wrong')
+
+        expect(failed_uri.reason).to eq('something went wrong')
+      end
+    end
+
+    describe '#inspect' do
+      it 'reports the correct class name' do
+        uri = described_class.success(URI.new('http://www.altmetric.com'))
+
+        expect(uri.inspect).to eq('#<Embiggen::EmbiggenedURI ' \
+                                  'http://www.altmetric.com>')
+      end
+    end
+  end
+end

--- a/spec/embiggen/uri_spec.rb
+++ b/spec/embiggen/uri_spec.rb
@@ -9,7 +9,7 @@ module Embiggen
 
         uri = described_class.new(URI('http://bit.ly/1ciyUPh'))
 
-        expect(uri.expand).to eq(URI('http://us.macmillan.com/books/9781466879980'))
+        expect(uri.expand).to embiggen_to(URI('http://us.macmillan.com/books/9781466879980'))
       end
 
       it 'marks expanded URIs as successful' do
@@ -27,7 +27,7 @@ module Embiggen
 
         uri = described_class.new(URI('https://youtu.be/dQw4w9WgXcQ'))
 
-        expect(uri.expand).to eq(URI('https://www.youtube.com/watch?v=dQw4w9WgXcQ&feature=youtu.be'))
+        expect(uri.expand).to embiggen_to(URI('https://www.youtube.com/watch?v=dQw4w9WgXcQ&feature=youtu.be'))
       end
 
       it 'expands URIs passed as strings' do
@@ -36,13 +36,13 @@ module Embiggen
 
         uri = described_class.new('http://bit.ly/1ciyUPh')
 
-        expect(uri.expand).to eq(URI('http://us.macmillan.com/books/9781466879980'))
+        expect(uri.expand).to embiggen_to(URI('http://us.macmillan.com/books/9781466879980'))
       end
 
       it 'does not expand unshortened URIs' do
         uri = described_class.new(URI('http://www.altmetric.com'))
 
-        expect(uri.expand).to eq(URI('http://www.altmetric.com'))
+        expect(uri.expand).to embiggen_to(URI('http://www.altmetric.com'))
       end
 
       it 'does not make requests for unshortened URIs' do
@@ -55,7 +55,7 @@ module Embiggen
         stub_request(:head, 'http://bit.ly/bad').to_return(:status => 500)
         uri = described_class.new(URI('http://bit.ly/bad'))
 
-        expect(uri.expand).to eq(URI('http://bit.ly/bad'))
+        expect(uri.expand).to embiggen_to(URI('http://bit.ly/bad'))
       end
 
       it 'marks erroring URIs as unsuccessful' do
@@ -69,7 +69,7 @@ module Embiggen
         stub_request(:head, 'http://bit.ly/bad').to_timeout
         uri = described_class.new(URI('http://bit.ly/bad'))
 
-        expect(uri.expand).to eq(URI('http://bit.ly/bad'))
+        expect(uri.expand).to embiggen_to(URI('http://bit.ly/bad'))
       end
 
       it 'marks timed out URIs as unsuccessful' do
@@ -83,7 +83,7 @@ module Embiggen
         stub_request(:head, 'http://bit.ly/bad').to_raise(Errno::ECONNRESET)
         uri = described_class.new(URI('http://bit.ly/bad'))
 
-        expect(uri.expand).to eq(URI('http://bit.ly/bad'))
+        expect(uri.expand).to embiggen_to(URI('http://bit.ly/bad'))
       end
 
       it 'marks URIs whose connection resets as unsuccessful' do
@@ -97,7 +97,7 @@ module Embiggen
         stub_request(:head, 'http://bit.ly/bad').to_timeout
         uri = described_class.new(URI('http://bit.ly/bad'))
 
-        expect(uri.expand(:timeout => 5)).to eq(URI('http://bit.ly/bad'))
+        expect(uri.expand(:timeout => 5)).to embiggen_to(URI('http://bit.ly/bad'))
       end
 
       it 'expands redirects to other shorteners' do
@@ -107,7 +107,7 @@ module Embiggen
                       'https://www.youtube.com/watch?v=dQw4w9WgXcQ&feature=youtu.be')
         uri = described_class.new(URI('http://bit.ly/98K8eH'))
 
-        expect(uri.expand).to eq(URI('https://www.youtube.com/watch?v=dQw4w9WgXcQ&feature=youtu.be'))
+        expect(uri.expand).to embiggen_to(URI('https://www.youtube.com/watch?v=dQw4w9WgXcQ&feature=youtu.be'))
       end
 
       it 'stops expanding redirects after a default threshold of 5' do
@@ -119,7 +119,7 @@ module Embiggen
         stub_redirect('http://bit.ly/6', 'http://bit.ly/7')
         uri = described_class.new(URI('http://bit.ly/1'))
 
-        expect(uri.expand).to eq(URI('http://bit.ly/6'))
+        expect(uri.expand).to embiggen_to(URI('http://bit.ly/6'))
       end
 
       it 'takes an optional redirect threshold' do
@@ -128,7 +128,7 @@ module Embiggen
         stub_redirect('http://bit.ly/3', 'http://bit.ly/4')
         uri = described_class.new(URI('http://bit.ly/1'))
 
-        expect(uri.expand(:redirects => 2)).to eq(URI('http://bit.ly/3'))
+        expect(uri.expand(:redirects => 2)).to embiggen_to(URI('http://bit.ly/3'))
       end
 
       it 'uses the threshold from the configuration' do
@@ -138,7 +138,7 @@ module Embiggen
         uri = described_class.new(URI('http://bit.ly/1'))
         Configuration.redirects = 2
 
-        expect(uri.expand).to eq(URI('http://bit.ly/3'))
+        expect(uri.expand).to embiggen_to(URI('http://bit.ly/3'))
       end
 
       it 'uses shorteners from the configuration' do
@@ -146,7 +146,7 @@ module Embiggen
         Configuration.shorteners << 'altmetric.it'
         uri = described_class.new(URI('http://altmetric.it'))
 
-        expect(uri.expand).to eq(URI('http://www.altmetric.com'))
+        expect(uri.expand).to embiggen_to(URI('http://www.altmetric.com'))
       end
 
       after do
@@ -163,13 +163,13 @@ module Embiggen
                       'https://www.youtube.com/watch?v=dQw4w9WgXcQ&feature=youtu.be')
         uri = described_class.new(URI('https://youtu.be/dQw4w9WgXcQ'))
 
-        expect(uri.expand!).to eq(URI('https://www.youtube.com/watch?v=dQw4w9WgXcQ&feature=youtu.be'))
+        expect(uri.expand!).to embiggen_to(URI('https://www.youtube.com/watch?v=dQw4w9WgXcQ&feature=youtu.be'))
       end
 
       it 'does not expand unshortened URIs' do
         uri = described_class.new(URI('http://www.altmetric.com'))
 
-        expect(uri.expand!).to eq(URI('http://www.altmetric.com'))
+        expect(uri.expand!).to embiggen_to(URI('http://www.altmetric.com'))
       end
 
       it 'raises an error if the URI redirects too many times' do
@@ -201,6 +201,20 @@ module Embiggen
         uri = described_class.new(URI('http://bit.ly/bad'))
 
         expect { uri.expand! }.to raise_error(::Errno::ECONNRESET)
+      end
+    end
+
+    describe '#uri' do
+      it 'returns the original URI' do
+        uri = described_class.new(URI('http://www.altmetric.com'))
+
+        expect(uri.uri).to eq(URI('http://www.altmetric.com'))
+      end
+
+      it 'returns a URI even if a string was passed' do
+        uri = described_class.new('http://www.altmetric.com')
+
+        expect(uri.uri).to eq(URI('http://www.altmetric.com'))
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,3 +18,13 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 end
+
+RSpec::Matchers.define :embiggen_to do |expected|
+  match do |actual|
+    actual.uri == expected
+  end
+
+  failure_message do |actual|
+    "expected that #{actual.uri} would equal #{expected}"
+  end
+end


### PR DESCRIPTION
As discussed in #1, rather than having two expansion methods (one gracefully handling errors but not communicating any information about them and one eagerly raising exceptions), consistently return a sum type from `expand` that both encapsulates exceptions and communicates success:

```ruby
uri = Embiggen::URI('http://examp.le/badlink').expand
#=> #<Embiggen::EmbiggenedURI http://examp.le/badlink>
uri.success?
#=> true or false
uri.reason
#=> 'following http://examp.le did not redirect'
uri.expand
```

This allows us to deprecate `expand!` but increases the amount of code for now (to accommodate the exceptions it raises).

An important change is that `Embiggen::URI` now delegates to its underlying `URI` object and `Embiggen::EmbiggenedURI` in turn delegates to an instance of `Embiggen::URI`. This creates the following delegation hierarchy:

         URI::Generic
             |
       Embiggen::URI
             |
    Embiggen::EmbiggenedURI

However, neither `SimpleDelegator` nor `DelegateClass` forward `is_a?` so the return types do not return `true` for `uri.is_a?(URI::HTTP)`, for example.

It may be that relying on delegation is a bad idea or, to take the other extreme, perhaps `EmbiggenedURI` should truly inherit from `URI::HTTP`.