### PR TITLE
Handle unencoded Location headers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     embiggen (0.1.0)
+      addressable (~> 2.3)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Embiggen [![Build Status](https://travis-ci.org/altmetric/embiggen.svg?branch=master)](https://travis-ci.org/altmetric/embiggen)
 
+**This branch describes the unreleased 1.x version of Embiggen, see the
+[master branch](https://github.com/altmetric/embiggen) for the current stable
+version.**
+
 A Ruby library to expand shortened URLs.
 
 **Current version:** 0.1.0  

--- a/embiggen.gemspec
+++ b/embiggen.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.files = %w(README.md LICENSE) + Dir['lib/**/*.rb']
   s.test_files = Dir['spec/**/*.rb']
 
+  s.add_dependency('addressable', '~> 2.3')
   s.add_development_dependency('rspec', '~> 3.2')
   s.add_development_dependency('webmock', '~> 1.21')
 end

--- a/lib/embiggen/uri.rb
+++ b/lib/embiggen/uri.rb
@@ -1,4 +1,5 @@
 require 'embiggen/configuration'
+require 'addressable/uri'
 require 'net/http'
 
 module Embiggen
@@ -6,7 +7,7 @@ module Embiggen
     attr_reader :uri
 
     def initialize(uri)
-      @uri = uri.is_a?(::URI::Generic) ? uri : URI(uri.to_s)
+      @uri = ::Addressable::URI.parse(uri).normalize
     end
 
     def expand(request_options = {})
@@ -60,7 +61,7 @@ module Embiggen
     end
 
     def http
-      http = ::Net::HTTP.new(uri.host, uri.port)
+      http = ::Net::HTTP.new(uri.host, uri.inferred_port)
       http.use_ssl = true if uri.scheme == 'https'
 
       http


### PR DESCRIPTION
GitHub: https://github.com/altmetric/embiggen/issues/4

In production, we've seen a few shorteners return unencoded URIs in their Location headers (contrary to the [RFC 7231 specification](http://tools.ietf.org/html/rfc7231#section-7.1.2)). We could use `URI.escape` and `URI.unescape` to deal with these but they have been deprecated. Instead, bring in the Addressable gem as a dependency to handle normalisation.

This means that Embiggen now returns `Addressable::URIs` rather than Ruby standard library `URI`s which is a breaking API change if you rely on `URI`-specific features (e.g. `port` which is much stricter with Addressable).
