### PR TITLE
Remove expand! in favour of EmbiggenedURIs

### DIFF
--- a/lib/embiggen/embiggened_uri.rb
+++ b/lib/embiggen/embiggened_uri.rb
@@ -1,0 +1,38 @@
+require 'embiggen/error'
+require 'forwardable'
+
+module Embiggen
+  class EmbiggenedURI
+    extend Forwardable
+    attr_reader :uri, :success, :error
+    alias_method :success?, :success
+    def_delegators :uri, :to_s, :fragment, :host, :path, :inferred_port, :port,
+                   :query, :scheme, :request_uri
+
+    def self.too_many_redirects(uri)
+      failure(uri, TooManyRedirects.for(uri))
+    end
+
+    def self.bad_shortened_uri(uri)
+      failure(uri, BadShortenedURI.for(uri))
+    end
+
+    def self.success(uri)
+      new(uri, :success => true)
+    end
+
+    def self.failure(uri, error = nil)
+      new(uri, :success => false, :error => error)
+    end
+
+    def initialize(uri, options = {})
+      @uri = uri
+      @success = options.fetch(:success) { !options.key?(:error) }
+      @error = options[:error]
+    end
+
+    def inspect
+      "#<#{self.class} #{self}>"
+    end
+  end
+end

--- a/lib/embiggen/error.rb
+++ b/lib/embiggen/error.rb
@@ -1,0 +1,16 @@
+module Embiggen
+  class Error < ::RuntimeError
+  end
+
+  class BadShortenedURI < Error
+    def self.for(uri)
+      new("following #{uri} did not redirect")
+    end
+  end
+
+  class TooManyRedirects < Error
+    def self.for(uri)
+      new("#{uri} redirected too many times")
+    end
+  end
+end

--- a/spec/embiggen/embiggened_uri_spec.rb
+++ b/spec/embiggen/embiggened_uri_spec.rb
@@ -1,0 +1,139 @@
+require 'embiggen'
+
+module Embiggen
+  RSpec.describe EmbiggenedURI do
+    describe '.success' do
+      it 'returns successful URIs' do
+        uri = described_class.success(
+          ::Addressable::URI.parse('http://www.altmetric.com'))
+
+        expect(uri).to be_success
+      end
+    end
+
+    describe '.failure' do
+      it 'returns unsuccessful URIs' do
+        failed_uri = described_class.failure(
+          ::Addressable::URI.parse('http://bit.ly/bad'))
+
+        expect(failed_uri).to_not be_success
+      end
+
+      it 'takes an optional cause for failure' do
+        uri = URI.new('http://bit.ly/bad')
+        error = Error.new('whoops')
+        failed_uri = described_class.failure(uri, error)
+
+        expect(failed_uri.error).to eq(error)
+      end
+    end
+
+    it 'defaults to being successful if there is no error' do
+      uri = described_class.new(
+        ::Addressable::URI.parse('http://www.altmetric.com'))
+
+      expect(uri).to be_success
+    end
+
+    describe '#uri' do
+      it 'returns the URI within' do
+        uri = described_class.success(
+          ::Addressable::URI.parse('http://www.altmetric.com'))
+
+        expect(uri.uri).to eq(
+          ::Addressable::URI.parse('http://www.altmetric.com'))
+      end
+    end
+
+    describe '#inspect' do
+      it 'reports the correct class name' do
+        uri = described_class.success(
+          ::Addressable::URI.parse('http://www.altmetric.com'))
+
+        expect(uri.inspect).to eq('#<Embiggen::EmbiggenedURI ' \
+                                  'http://www.altmetric.com>')
+      end
+    end
+
+    describe '#to_s' do
+      it 'returns the URI as a string' do
+        uri = described_class.success(
+          ::Addressable::URI.parse('http://www.altmetric.com'))
+
+        expect(uri.to_s).to eq('http://www.altmetric.com')
+      end
+    end
+
+    describe '#host' do
+      it 'returns the host of the URI' do
+        uri = described_class.success(
+          ::Addressable::URI.parse('http://www.altmetric.com'))
+
+        expect(uri.host).to eq('www.altmetric.com')
+      end
+    end
+
+    describe '#port' do
+      it 'returns the port of the URI' do
+        uri = described_class.success(
+          ::Addressable::URI.parse('http://www.altmetric.com'))
+
+        expect(uri.port).to be_nil
+      end
+    end
+
+    describe '#inferred_port' do
+      it 'returns the inferred port of the URI' do
+        uri = described_class.success(
+          ::Addressable::URI.parse('http://www.altmetric.com'))
+
+        expect(uri.inferred_port).to eq(80)
+      end
+    end
+
+    describe '#path' do
+      it 'returns the path of the URI' do
+        uri = described_class.success(
+          ::Addressable::URI.parse('http://www.altmetric.com/foo?123'))
+
+        expect(uri.path).to eq('/foo')
+      end
+    end
+
+    describe '#scheme' do
+      it 'returns the scheme of the URI' do
+        uri = described_class.success(
+          ::Addressable::URI.parse('http://www.altmetric.com'))
+
+        expect(uri.scheme).to eq('http')
+      end
+    end
+
+    describe '#request_uri' do
+      it 'returns the request URI of the URI' do
+        uri = described_class.success(
+          ::Addressable::URI.parse('http://www.altmetric.com/foo?123'))
+
+        expect(uri.request_uri).to eq('/foo?123')
+      end
+    end
+
+    describe '#fragment' do
+      it 'returns the fragment of the URI' do
+        uri = described_class.success(
+          ::Addressable::URI.parse('http://www.altmetric.com/#foo'))
+
+        expect(uri.fragment).to eq('foo')
+      end
+    end
+
+    describe '#query' do
+      it 'returns the query string of the URI' do
+        uri = described_class.success(
+          ::Addressable::URI.parse('http://www.altmetric.com?foo=123'))
+
+        expect(uri.query).to eq('foo=123')
+      end
+    end
+  end
+end


### PR DESCRIPTION
GitHub: https://github.com/altmetric/embiggen/issues/1

As discussed in #1, rather than having two expansion methods (one gracefully handling errors but not communicating any information about them and one eagerly raising exceptions), consistently return a sum type from `expand` that both encapsulates exceptions and communicates success:

```ruby
uri = Embiggen::URI('http://examp.le/badlink').expand
#=> #<Embiggen::EmbiggenedURI http://examp.le/badlink>
uri.success?
#=> true or false
uri.error
#=> #<Embiggen::BadShortenedURI ...>
uri.to_s
#=> 'http://examp.le/badlink'
```

`Embiggen::EmbiggenedURI` delegates to an internal `Addresssable::URI` but does so explicitly through `Forwardable` rather than `SimpleDelegator`: some methods are delegated (e.g. `host`, `inferred_port`, `request_uri`) but only for convenience and the true way to get a `URI` instance is to use `Embiggen::EmbiggenedURI#uri`.
