### PR TITLE
Raises an error if the response is not a valid URI

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+ruby:
+  config_file: .rubocop.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,10 @@ Lint/HandleExceptions:
   Exclude:
     - Rakefile
 
+# Overwrite Hound default
+Style/StringLiterals:
+  EnforcedStyle: single_quotes
+
 # For Ruby 1.8 compatibility
 Style/DotPosition:
   EnforcedStyle: trailing

--- a/lib/embiggen/uri.rb
+++ b/lib/embiggen/uri.rb
@@ -41,10 +41,22 @@ module Embiggen
       timeout = request_options.fetch(:timeout) { Configuration.timeout }
 
       location = http_client.follow(timeout)
+      check_location(location)
+
+      location
+    end
+
+    def check_location(location)
       fail BadShortenedURI.new(
         "following #{uri} did not redirect", uri) unless location
 
-      location
+      parsed_uri = Addressable::URI.parse(location)
+      return if parsed_uri.scheme && parsed_uri.host && parsed_uri.path
+
+      fail Addressable::URI::InvalidURIError
+    rescue Addressable::URI::InvalidURIError
+      raise BadShortenedURI.new(
+        "following #{uri} returns a not valid URI", uri)
     end
   end
 end

--- a/spec/embiggen/uri_spec.rb
+++ b/spec/embiggen/uri_spec.rb
@@ -95,6 +95,13 @@ module Embiggen
         expect { uri.expand }.to raise_error(BadShortenedURI)
       end
 
+      it 'raises and error if the URI returned is not valid' do
+        stub_redirect('http://bit.ly/suspicious', '|cat /etc/passwd')
+        uri = described_class.new('http://bit.ly/suspicious')
+
+        expect { uri.expand }.to raise_error(BadShortenedURI)
+      end
+
       it 'retains the last URI if a shortened URI does not redirect' do
         stub_redirect('http://bit.ly/bad', 'http://bit.ly/bad2')
         stub_request(:head, 'http://bit.ly/bad2').to_return(:status => 500)


### PR DESCRIPTION
Checks the `location` response for a valid URI and raises `BadShortenedURI` error in case it isn't.

Fixes #11 