### PR TITLE
Simplify shorteners API to only include?

### DIFF
--- a/lib/embiggen/configuration.rb
+++ b/lib/embiggen/configuration.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require 'set'
+require 'embiggen/shortener_list'
 
 module Embiggen
   class Configuration
@@ -17,7 +18,7 @@ module Embiggen
 
     # From http://longurl.org/services
     def self.shorteners
-      @shorteners ||= Set.new(%w(
+      @shorteners ||= ShortenerList.new(%w(
         0rz.tw 1link.in 1url.com 2.gp 2big.at 2tu.us 3.ly 307.to 4ms.me
         4sq.com 4url.cc 6url.com 7.ly a.gg a.nf aa.cx abcurl.net ad.vu adf.ly
         adjix.com afx.cc all.fuseurl.com alturl.com amzn.to ar.gy arst.ch

--- a/lib/embiggen/shortener_list.rb
+++ b/lib/embiggen/shortener_list.rb
@@ -1,0 +1,25 @@
+require 'forwardable'
+require 'set'
+
+module Embiggen
+  class ShortenerList
+    extend Forwardable
+    extend Enumerable
+
+    attr_reader :domains
+
+    def initialize(domains)
+      @domains = Set.new(domains)
+    end
+
+    def include?(uri)
+      domains.any? { |domain| uri.host =~ /\b#{domain}\z/i }
+    end
+
+    def +(other)
+      self.class.new(domains + other)
+    end
+
+    def_delegators :domains, :<<, :size, :delete, :empty?, :each
+  end
+end

--- a/lib/embiggen/shortener_list.rb
+++ b/lib/embiggen/shortener_list.rb
@@ -4,7 +4,7 @@ require 'set'
 module Embiggen
   class ShortenerList
     extend Forwardable
-    extend Enumerable
+    include Enumerable
 
     attr_reader :domains
 

--- a/lib/embiggen/uri.rb
+++ b/lib/embiggen/uri.rb
@@ -24,7 +24,7 @@ module Embiggen
     end
 
     def shortened?
-      Configuration.shorteners.any? { |domain| uri.host =~ /\b#{domain}\z/i }
+      Configuration.shorteners.include?(uri)
     end
 
     private

--- a/spec/embiggen/shortener_list_spec.rb
+++ b/spec/embiggen/shortener_list_spec.rb
@@ -1,0 +1,80 @@
+require 'embiggen/shortener_list'
+
+RSpec.describe Embiggen::ShortenerList do
+  describe '#new' do
+    it 'can be given a set' do
+      list = described_class.new(Set['a.com', 'b.com', 'b.com'])
+
+      expect(list.size).to eq(2)
+    end
+
+    it 'converts a given enumerable to a set' do
+      list = described_class.new(%w(a.com a.com))
+
+      expect(list.size).to eq(1)
+    end
+  end
+
+  describe '#include?' do
+    it 'returns true if a URL host is on the whitelist' do
+      list = described_class.new(%w(bit.ly))
+
+      expect(list).to include(URI('http://bit.ly/foo'))
+    end
+
+    it 'returns false if a URL host is not on the whitelist' do
+      list = described_class.new(%w(bit.ly))
+
+      expect(list).to_not include(URI('http://www.altmetric.com'))
+    end
+  end
+
+  describe '#<<' do
+    it 'appends domains to the list' do
+      list = described_class.new([])
+      list << 'bit.ly'
+
+      expect(list).to include(URI('http://bit.ly/foo'))
+    end
+
+    it 'can be chained' do
+      list = described_class.new([])
+      list << 'bit.ly' << 'a.com'
+
+      expect(list).to include(URI('http://bit.ly/foo'), URI('http://a.com/bar'))
+    end
+  end
+
+  describe '#size' do
+    it 'returns the number of domains in the list' do
+      list = described_class.new(%w(bit.ly ow.ly))
+
+      expect(list.size).to eq(2)
+    end
+  end
+
+  describe '#delete' do
+    it 'removes domains from the list' do
+      list = described_class.new(%w(bit.ly))
+      list.delete('bit.ly')
+
+      expect(list).to be_empty
+    end
+  end
+
+  describe '#+' do
+    it 'appends a list of domains to the existing one' do
+      list = described_class.new(%w(bit.ly))
+      list += %w(a.com)
+
+      expect(list).to include(URI('http://a.com/foo'))
+    end
+
+    it 'can combine two lists' do
+      list = described_class.new(%w(bit.ly))
+      list += described_class.new(%w(a.com))
+
+      expect(list).to include(URI('http://a.com/foo'))
+    end
+  end
+end

--- a/spec/embiggen/shortener_list_spec.rb
+++ b/spec/embiggen/shortener_list_spec.rb
@@ -77,4 +77,10 @@ RSpec.describe Embiggen::ShortenerList do
       expect(list).to include(URI('http://a.com/foo'))
     end
   end
+
+  it 'is enumerable for 1.8 compatiblity' do
+    list = described_class.new([])
+
+    expect(list).to be_kind_of(Enumerable)
+  end
 end


### PR DESCRIPTION
GitHub: #2

Allow users to supply their own object for `Embiggen::Configuration.shorteners` that only responds to `include?` to determine whether a URI is shortened or not.

This replaces the current `Set` implementation with a `ShortenerList` class that has the same API (to keep testing simple) but exposes a custom `include?` method.