### PR TITLE
Added & Removed some shoreteners

### DIFF
--- a/lib/embiggen/configuration.rb
+++ b/lib/embiggen/configuration.rb
@@ -21,28 +21,28 @@ module Embiggen
       @shorteners ||= ShortenerList.new(%w(
         0rz.tw 1link.in 1url.com 2.gp 2big.at 2tu.us 3.ly 307.to 4ms.me
         4sq.com 4url.cc 6url.com 7.ly a.gg a.nf aa.cx abcurl.net ad.vu adf.ly
-        adjix.com afx.cc all.fuseurl.com alturl.com amzn.to ar.gy arst.ch
-        atu.ca azc.cc b23.ru b2l.me bacn.me bcool.bz binged.it bit.ly bizj.us
-        bloat.me bravo.ly bsa.ly budurl.com canurl.com chilp.it chzb.gr cl.lk
-        cl.ly clck.ru cli.gs cliccami.info clickthru.ca clop.in conta.cc
-        cort.as cot.ag crks.me ctvr.us cutt.us dai.ly decenturl.com dfl8.me
-        digbig.com digg.com disq.us dld.bz dlvr.it do.my doiop.com dopen.us
-        easyuri.com easyurl.net eepurl.com eweri.com fa.by fav.me fb.me
-        fbshare.me ff.im fff.to fire.to firsturl.de firsturl.net flic.kr
-        flq.us fly2.ws fon.gs freak.to fuseurl.com fuzzy.to fwd4.me fwib.net
-        g.ro.lt gizmo.do gl.am go.9nl.com go.ign.com go.usa.gov goo.gl
-        goshrink.com gurl.es hex.io hiderefer.com hmm.ph href.in hsblinks.com
-        htxt.it huff.to hulu.com hurl.me hurl.ws icanhaz.com idek.net ilix.in
-        is.gd its.my ix.lt j.mp jijr.com kl.am klck.me korta.nu krunchd.com
-        l9k.net lat.ms liip.to liltext.com linkbee.com linkbun.ch liurl.cn
-        ln-s.net ln-s.ru lnk.gd lnk.ms lnkd.in lnkurl.com lru.jp lt.tl lurl.no
-        macte.ch mash.to merky.de migre.me miniurl.com minurl.fr mke.me
-        moby.to moourl.com mrte.ch myloc.me myurl.in n.pr nbc.co nblo.gs nn.nf
-        not.my notlong.com nsfw.in nutshellurl.com nxy.in nyti.ms o-x.fr
-        oc1.us om.ly omf.gd omoikane.net on.cnn.com on.mktw.net onforb.es
-        orz.se ow.ly ping.fm pli.gs pnt.me politi.co post.ly pp.gg profile.to
-        ptiturl.com pub.vitrue.com qlnk.net qte.me qu.tc qy.fi r.im rb6.me
-        read.bi readthis.ca reallytinyurl.com redir.ec stub_redirects.ca
+        adfoc.us adjix.com afx.cc all.fuseurl.com alturl.com amzn.to ar.gy
+        arst.ch atu.ca azc.cc b23.ru b2l.me bacn.me bcool.bz bc.vc binged.it
+        bit.ly bit.do bizj.us bloat.me bravo.ly bsa.ly budurl.com canurl.com
+        chilp.it chzb.gr cl.lk cl.ly clck.ru cli.gs cliccami.info clickthru.ca
+        clop.in conta.cc cort.as cot.ag crks.me ctvr.us cutt.us dai.ly
+        decenturl.com dfl8.me digbig.com digg.com disq.us dld.bz dlvr.it do.my
+        doiop.com dopen.us easyuri.com easyurl.net eepurl.com eweri.com fa.by
+        fav.me fb.me fbshare.me ff.im fff.to fire.to firsturl.de firsturl.net
+        flic.kr flq.us fly2.ws fon.gs freak.to fuseurl.com fuzzy.to fur.ly
+        fwd4.me fwib.net g.ro.lt gizmo.do gl.am go.9nl.com go.ign.com go.usa.gov
+        goo.gl goshrink.com gurl.es hex.io hiderefer.com hmm.ph href.in
+        hsblinks.com htxt.it huff.to hulu.com hurl.me hurl.ws icanhaz.com
+        idek.net ilix.in is.gd its.my ix.lt j.mp jijr.com kl.am klck.me
+        korta.nu krunchd.com l9k.net lat.ms liip.to liltext.com linkbee.com
+        linkbun.ch liurl.cn ln-s.net ln-s.ru lnk.gd lnk.ms lnkd.in lnkurl.com
+        lru.jp lt.tl lurl.no macte.ch mash.to merky.de migre.me miniurl.com
+        minurl.fr mke.me moby.to moourl.com mrte.ch myloc.me myurl.in n.pr
+        nbc.co nblo.gs nn.nf not.my notlong.com nsfw.in nutshellurl.com nxy.in
+        nyti.ms o-x.fr oc1.us om.ly omf.gd omoikane.net on.cnn.com on.mktw.net
+        onforb.es orz.se ow.ly ping.fm pli.gs pnt.me politi.co post.ly pp.gg
+        profile.to ptiturl.com pub.vitrue.com qlnk.net qte.me qu.tc qy.fi r.im
+        rb6.me read.bi readthis.ca reallytinyurl.com redir.ec seomafia.net
         redirx.com retwt.me ri.ms rickroll.it riz.gd rt.nu ru.ly rubyurl.com
         rurl.org rww.tw s4c.in s7y.us safe.mn sameurl.com sdut.us shar.es
         shink.de shorl.com short.ie short.to shortlinks.co.uk shorturl.com


### PR DESCRIPTION
Added shoreteners: bc.vc adfoc.us bit.do seomafia.net fur.ly
Removed shoreteners: stub_redirects.ca


As a side, I felt the list in the code is a a bit too hard to work with (sort, check if present, read through), would you take a separate PR that switches that to read the content from a local txt/cfg file?

This will also allow sending a filename into the gem such that it's possible to configure a clean or extended list from external code.

Thoughts?

