### PR TITLE
[FIX] Setup the regexp to match domain name once, a 50%~ speed up

### DIFF
--- a/lib/embiggen/shortener_list.rb
+++ b/lib/embiggen/shortener_list.rb
@@ -9,17 +9,31 @@ module Embiggen
     attr_reader :domains
 
     def initialize(domains)
-      @domains = Set.new(domains)
+      @domains = Set.new(domains.map { |domain| host_pattern(domain) })
     end
 
     def include?(uri)
-      domains.any? { |domain| uri.host =~ /\b#{domain}\z/i }
+      domains.any? { |domain| uri.host =~ domain }
     end
 
     def +(other)
       self.class.new(domains + other)
     end
 
-    def_delegators :domains, :<<, :size, :delete, :empty?, :each
+    def <<(domain)
+      domains << host_pattern(domain)
+
+      self
+    end
+
+    def delete(domain)
+      domains.delete(host_pattern(domain))
+    end
+
+    def_delegators :domains, :size, :empty?, :each
+
+    def host_pattern(domain)
+      /\b#{domain}\z/i
+    end
   end
 end

--- a/spec/embiggen/shortener_list_spec.rb
+++ b/spec/embiggen/shortener_list_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe Embiggen::ShortenerList do
 
       expect(list).to_not include(URI('http://www.altmetric.com'))
     end
+
+    it 'returns true if a URL host without a subdomain is on the whitelist' do
+      list = described_class.new(%w(bit.ly))
+
+      expect(list).to include(URI('http://www.bit.ly/foo'))
+    end
   end
 
   describe '#<<' do


### PR DESCRIPTION
**Before:**

```sh
› for i in {1..5}; do bundle exec rspec | grep Finished ; done | cut -d" " -f 3
0.14006
0.13448
0.15444
0.16009
0.1727
```

**After:**

````sh
› for i in {1..5}; do bundle exec rspec | grep Finished ; done | cut -d" " -f 3
0.06168
0.05892
0.06377
0.06042
0.06269
```

All tests seem to pass.
So cases such as "nobitly.com" or "bitl.c" are not matched because the test is to find an exact match in the url list.