### PR TITLE
Add explicit permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - '**'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fix code scanning alert: actions/missing-workflow-permissions

The CI workflow was missing explicit permissions declarations. This adds
`contents: read` permission following the principle of least privilege,
as the workflow only needs to read repository contents to run tests.