### PR TITLE
Add kidney.pub to shorteners list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.9.0] - 2026-04-23
+
+### Changed
+
+- Added 1 new shortener (`kidney.pub`)
+
 ## [1.8.0] - 2025-05-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@
 
 A Ruby library to expand shortened URLs.
 
-**Current version:** 1.8.0  
+**Current version:** 1.9.0  
 **Supported Ruby versions:** >= 2.7
 
 ## Installation
 
 ```
-gem install embiggen -v '~> 1.7'
+gem install embiggen -v '~> 1.8'
 ```
 
 Or, in your `Gemfile`:
 
 ```ruby
-gem 'embiggen', '~> 1.7'
+gem 'embiggen', '~> 1.8'
 ```
 
 ## Usage

--- a/embiggen.gemspec
+++ b/embiggen.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'embiggen'
-  s.version = '1.8.0'
+  s.version = '1.9.0'
   s.summary = 'A library to expand shortened URLs'
   s.description = <<-EOF
     A library to expand shortened URIs, respecting timeouts, following

--- a/shorteners.txt
+++ b/shorteners.txt
@@ -4375,6 +4375,7 @@ kicking.horse
 kickson.fr
 kickz.cc
 kidd.tv
+kidney.pub
 kidneymi.org
 kidsf.it
 kidshelpline.info


### PR DESCRIPTION
Adds kidney.pub (used by ASN to share publications on X) to the shorteners list and bumps the version to 1.9.0.