### PR TITLE
Add support for non-redirect shorteners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.10.0] - 2026-04-27
+
+### Added
+
+- Support for non-redirect shorteners (e.g. `lnkd.in`, `ebx.sh`) that serve
+  an HTML page instead of issuing an HTTP redirect; the destination URL is
+  extracted via a configurable CSS selector
+
+### Fixed
+
+- `require 'set'` was missing from `ShortenerList`, causing a `NameError` on
+  Ruby 3.2+ where `Set` is no longer auto-loaded
+- Domain strings were not escaped before being interpolated into regexes in
+  `ShortenerList` and `NonRedirectShortenerList`, so a dot in a domain name
+  (e.g. `bit.ly`) would match any character rather than a literal dot
+- `ShortenerList#+` re-processed already-compiled `Regexp` patterns through
+  `host_pattern`, double-wrapping them and raising a `TypeError` once
+  `Regexp.escape` was introduced
+
 ## [1.9.0] - 2026-04-23
 
 ### Changed
@@ -112,6 +131,11 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - First stable version of Embiggen and its API for expanding shortened links.
 
+[1.10.0]: https://github.com/altmetric/embiggen/releases/tag/v1.10.0
+[1.9.0]: https://github.com/altmetric/embiggen/releases/tag/v1.9.0
+[1.8.0]: https://github.com/altmetric/embiggen/releases/tag/v1.8.0
+[1.7.0]: https://github.com/altmetric/embiggen/releases/tag/v1.7.0
+[1.6.0]: https://github.com/altmetric/embiggen/releases/tag/v1.6.0
 [1.5.0]: https://github.com/altmetric/embiggen/releases/tag/v1.5.0
 [1.4.0]: https://github.com/altmetric/embiggen/releases/tag/v1.4.0
 [1.3.0]: https://github.com/altmetric/embiggen/releases/tag/v1.3.0

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Ruby library to expand shortened URLs.
 
-**Current version:** 1.9.0  
+**Current version:** 1.10.0  
 **Supported Ruby versions:** >= 2.7
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -61,6 +61,40 @@ Embiggen.configure do |config|
 end
 ```
 
+## Non-redirect shorteners
+
+Some URL shorteners (such as [LinkedIn's lnkd.in](https://lnkd.in)) do not
+issue HTTP redirects when used with an external domain.
+Instead, they serve an HTML page containing the
+destination URL in a known element. Embiggen supports these by fetching the
+page and extracting the link via a CSS selector.
+
+Embiggen ships with a default list of known non-redirect shorteners in
+[`non_redirect_shorteners.yml`](https://github.com/altmetric/embiggen/blob/master/non_redirect_shorteners.yml),
+mapping each domain to the CSS selector used to locate the destination link.
+
+```ruby
+# Expanding a LinkedIn shortened URL
+Embiggen::URI('https://lnkd.in/eB25Z2yS').expand
+#=> #<URI::HTTPS https://example.com/article>
+```
+
+You can add your own non-redirect shorteners or remove existing ones via
+`Embiggen.configure`:
+
+```ruby
+Embiggen.configure do |config|
+  # Add a new non-redirect shortener
+  config.non_redirect_shorteners['myshorten.er'] = 'article a.destination'
+
+  # Remove a specific shortener
+  config.non_redirect_shorteners.delete('lnkd.in')
+
+  # Opt out of the feature entirely
+  config.non_redirect_shorteners.clear
+end
+```
+
 ## Shorteners
 
 Embiggen ships with a default list of URL shortening service domains (c.f.
@@ -191,7 +225,9 @@ Override the following settings:
 * `redirects`: the default number of redirects to follow (can be overridden by
   passing options to `Embiggen::URI#expand`);
 * `shorteners`: the list of domains of shortening services, c.f.
-  [Shorteners](#shorteners).
+  [Shorteners](#shorteners);
+* `non_redirect_shorteners`: the mapping of non-redirect shortener domains to
+  CSS selectors, c.f. [Non-redirect shorteners](#non-redirect-shorteners).
 
 ## Acknowledgements
 

--- a/embiggen.gemspec
+++ b/embiggen.gemspec
@@ -10,10 +10,11 @@ Gem::Specification.new do |s|
   s.authors = ['Paul Mucur', 'Jonathan Hernandez']
   s.email = 'support@altmetric.com'
   s.homepage = 'https://github.com/altmetric/embiggen'
-  s.files = %w[README.md LICENSE shorteners.txt] + Dir['lib/**/*.rb']
+  s.files = %w[README.md LICENSE shorteners.txt non_redirect_shorteners.yml] + Dir['lib/**/*.rb']
   s.test_files = Dir['spec/**/*.rb']
 
   s.add_dependency('addressable', '~> 2.3')
+  s.add_dependency('nokogiri')
 
   s.add_development_dependency('rspec')
   s.add_development_dependency('webmock')

--- a/embiggen.gemspec
+++ b/embiggen.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'embiggen'
-  s.version = '1.9.0'
+  s.version = '1.10.0'
   s.summary = 'A library to expand shortened URLs'
   s.description = <<-EOF
     A library to expand shortened URIs, respecting timeouts, following

--- a/lib/embiggen/configuration.rb
+++ b/lib/embiggen/configuration.rb
@@ -1,10 +1,12 @@
 # encoding: utf-8
 require 'embiggen/shortener_list'
+require 'embiggen/non_redirect_shortener_list'
+require 'yaml'
 
 module Embiggen
   class Configuration
     class << self
-      attr_writer :timeout, :redirects, :shorteners
+      attr_writer :timeout, :redirects, :shorteners, :non_redirect_shorteners
     end
 
     def self.timeout
@@ -23,6 +25,15 @@ module Embiggen
     def self.shorteners_from_file
       file_path = File.expand_path('../../shorteners.txt', __dir__)
       File.readlines(file_path).map(&:chomp)
+    end
+
+    def self.non_redirect_shorteners
+      @non_redirect_shorteners ||= NonRedirectShortenerList.new(non_redirect_shorteners_from_file)
+    end
+
+    def self.non_redirect_shorteners_from_file
+      file_path = File.expand_path('../../non_redirect_shorteners.yml', __dir__)
+      YAML.safe_load(File.read(file_path))
     end
   end
 end

--- a/lib/embiggen/html_client.rb
+++ b/lib/embiggen/html_client.rb
@@ -1,0 +1,42 @@
+require 'embiggen/error'
+require 'net/http'
+require 'nokogiri'
+
+module Embiggen
+  class HtmlClient
+    attr_reader :uri
+
+    def initialize(uri)
+      @uri = uri
+      @http = ::Net::HTTP.new(uri.host, uri.port)
+      @http.use_ssl = true if uri.scheme == 'https'
+    end
+
+    def follow(timeout, selector)
+      response = request(timeout)
+      return unless response.is_a?(::Net::HTTPOK)
+
+      document = Nokogiri::HTML(response.body)
+      element = document.at_css(selector)
+      element&.[]('href')
+    rescue ::Timeout::Error => e
+      raise NetworkError.new(
+        "Timeout::Error: could not follow #{uri}: #{e.message}", uri
+      )
+    rescue StandardError => e
+      raise NetworkError.new(
+        "StandardError: could not follow #{uri}: #{e.message}", uri
+      )
+    end
+
+    private
+
+    def request(timeout)
+      request = ::Net::HTTP::Get.new(uri.request_uri)
+      @http.open_timeout = timeout
+      @http.read_timeout = timeout
+
+      @http.request(request)
+    end
+  end
+end

--- a/lib/embiggen/non_redirect_shortener_list.rb
+++ b/lib/embiggen/non_redirect_shortener_list.rb
@@ -1,0 +1,41 @@
+module Embiggen
+  class NonRedirectShortenerList
+    attr_reader :domains
+
+    def initialize(domains)
+      @domains = domains.to_h.transform_keys { |domain| host_pattern(domain) }
+    end
+
+    def supported?(uri)
+      !selector_for(uri).nil?
+    end
+
+    def selector_for(uri)
+      _, selector = domains.find { |pattern, _| uri.host =~ pattern }
+      selector
+    end
+
+    def []=(domain, selector)
+      domains[host_pattern(domain)] = selector
+    end
+
+    def delete(domain)
+      domains.delete(host_pattern(domain))
+    end
+
+    def clear
+      domains.clear
+      self
+    end
+
+    def size
+      domains.size
+    end
+
+    private
+
+    def host_pattern(domain)
+      /\b#{Regexp.escape(domain)}\z/i
+    end
+  end
+end

--- a/lib/embiggen/shortener_list.rb
+++ b/lib/embiggen/shortener_list.rb
@@ -33,7 +33,7 @@ module Embiggen
     def_delegators :domains, :size, :empty?, :each
 
     def host_pattern(domain)
-      /\b#{domain}\z/i
+      /\b#{Regexp.escape(domain)}\z/i
     end
   end
 end

--- a/lib/embiggen/shortener_list.rb
+++ b/lib/embiggen/shortener_list.rb
@@ -1,4 +1,5 @@
 require 'forwardable'
+require 'set'
 
 module Embiggen
   class ShortenerList

--- a/lib/embiggen/shortener_list.rb
+++ b/lib/embiggen/shortener_list.rb
@@ -17,7 +17,15 @@ module Embiggen
     end
 
     def +(other)
-      self.class.new(domains + other)
+      other_patterns = if other.respond_to?(:domains)
+                         other.domains
+                       else
+                         Set.new(other.map { |d| host_pattern(d) })
+                       end
+
+      self.class.allocate.tap do |result|
+        result.instance_variable_set(:@domains, domains | other_patterns)
+      end
     end
 
     def <<(domain)

--- a/lib/embiggen/uri.rb
+++ b/lib/embiggen/uri.rb
@@ -1,5 +1,6 @@
 require 'embiggen/configuration'
 require 'embiggen/error'
+require 'embiggen/html_client'
 require 'embiggen/http_client'
 require 'addressable/uri'
 require 'uri'
@@ -44,6 +45,14 @@ module Embiggen
       timeout = request_options.fetch(:timeout) { Configuration.timeout }
 
       location = http_client.follow(timeout)
+
+      if location.nil?
+        non_redirect_shorteners = Configuration.non_redirect_shorteners
+        if non_redirect_shorteners.supported?(uri)
+          location = HtmlClient.new(uri).follow(timeout, non_redirect_shorteners.selector_for(uri))
+        end
+      end
+
       unless followable?(location)
         fail BadShortenedURI.new(
           "following #{uri} did not redirect", uri

--- a/non_redirect_shorteners.yml
+++ b/non_redirect_shorteners.yml
@@ -1,0 +1,2 @@
+lnkd.in: "main a"
+ebx.sh: "body a#urlToFollow"

--- a/spec/embiggen/html_client_spec.rb
+++ b/spec/embiggen/html_client_spec.rb
@@ -1,0 +1,47 @@
+# encoding: utf-8
+require 'embiggen/html_client'
+
+module Embiggen
+  RSpec.describe HtmlClient do
+    describe '#follow' do
+      let(:uri) { URI('https://lnkd.in/eB25Z2yS') }
+      let(:client) { described_class.new(uri) }
+
+      it 'returns the href from the matched element' do
+        stub_request(:get, 'https://lnkd.in/eB25Z2yS')
+          .to_return(
+            status: 200,
+            body: '<html><body><main><a href="https://example.com/article">https://example.com/article</a></main></body></html>',
+            headers: { 'Content-Type' => 'text/html' }
+          )
+
+        expect(client.follow(1, 'main a')).to eq('https://example.com/article')
+      end
+
+      it 'returns nil when the response is not 200 OK' do
+        stub_request(:get, 'https://lnkd.in/eB25Z2yS').to_return(status: 302, headers: { 'Location' => 'https://example.com' })
+
+        expect(client.follow(1, 'main a')).to be_nil
+      end
+
+      it 'returns nil when no element matches the selector' do
+        stub_request(:get, 'https://lnkd.in/eB25Z2yS')
+          .to_return(status: 200, body: '<html><body><p>No link here</p></body></html>')
+
+        expect(client.follow(1, 'main a')).to be_nil
+      end
+
+      it 'raises a network error if the URI times out' do
+        stub_request(:get, 'https://lnkd.in/eB25Z2yS').to_timeout
+
+        expect { client.follow(1, 'main a') }.to raise_error(NetworkError)
+      end
+
+      it 'raises a network error if the connection resets' do
+        stub_request(:get, 'https://lnkd.in/eB25Z2yS').to_raise(::Errno::ECONNRESET)
+
+        expect { client.follow(1, 'main a') }.to raise_error(NetworkError)
+      end
+    end
+  end
+end

--- a/spec/embiggen/non_redirect_shortener_list_spec.rb
+++ b/spec/embiggen/non_redirect_shortener_list_spec.rb
@@ -1,0 +1,46 @@
+require 'embiggen/non_redirect_shortener_list'
+
+RSpec.describe Embiggen::NonRedirectShortenerList do
+  describe '#supported?' do
+    it 'returns true for a URI whose host is in the list' do
+      list = described_class.new('lnkd.in' => 'main a')
+
+      expect(list.supported?(URI('https://lnkd.in/eB25Z2yS'))).to be(true)
+    end
+
+    it 'returns false for a URI whose host is not in the list' do
+      list = described_class.new('lnkd.in' => 'main a')
+
+      expect(list.supported?(URI('https://example.com/foo'))).to be(false)
+    end
+  end
+
+  describe '#selector_for' do
+    it 'returns the selector for a matching URI' do
+      list = described_class.new('lnkd.in' => 'main a')
+
+      expect(list.selector_for(URI('https://lnkd.in/eB25Z2yS'))).to eq('main a')
+    end
+
+    it 'returns nil for a non-matching URI' do
+      list = described_class.new('lnkd.in' => 'main a')
+
+      expect(list.selector_for(URI('https://example.com/foo'))).to be_nil
+    end
+
+    it 'returns nil if the URI only matches due to an unescaped dot' do
+      list = described_class.new('lnkd.in' => 'main a')
+
+      expect(list.selector_for(URI('https://lnkdXin/foo'))).to be_nil
+    end
+  end
+
+  describe '#clear' do
+    it 'removes all entries' do
+      list = described_class.new('lnkd.in' => 'main a')
+      list.clear
+
+      expect(list.size).to eq(0)
+    end
+  end
+end

--- a/spec/embiggen/shortener_list_spec.rb
+++ b/spec/embiggen/shortener_list_spec.rb
@@ -88,6 +88,20 @@ RSpec.describe Embiggen::ShortenerList do
 
       expect(list).to include(URI('http://a.com/foo'))
     end
+
+    it 'retains the original domains when combining two lists' do
+      list = described_class.new(%w[bit.ly])
+      list += described_class.new(%w[a.com])
+
+      expect(list).to include(URI('http://bit.ly/foo'))
+    end
+
+    it 'returns a list with the combined size' do
+      list = described_class.new(%w[bit.ly])
+      list += described_class.new(%w[a.com])
+
+      expect(list.size).to eq(2)
+    end
   end
 
   it 'is enumerable for 1.8 compatiblity' do

--- a/spec/embiggen/shortener_list_spec.rb
+++ b/spec/embiggen/shortener_list_spec.rb
@@ -33,6 +33,12 @@ RSpec.describe Embiggen::ShortenerList do
 
       expect(list).to include(URI('http://www.bit.ly/foo'))
     end
+
+    it 'returns false if a URL host only matches due to an unescaped dot' do
+      list = described_class.new(%w[i.ea.com])
+
+      expect(list).not_to include(URI('http://www.ikea.com/foo'))
+    end
   end
 
   describe '#<<' do

--- a/spec/embiggen/uri_spec.rb
+++ b/spec/embiggen/uri_spec.rb
@@ -209,6 +209,26 @@ module Embiggen
         expect(uri.expand).to eq(URI('http://www.altmetric.com'))
       end
 
+      it 'expands non-redirect shorteners by parsing HTML' do
+        stub_request(:get, 'https://lnkd.in/eB25Z2yS')
+          .to_return(
+            status: 200,
+            body: '<html><body><main><a href="https://example.com/article">https://example.com/article</a></main></body></html>',
+            headers: { 'Content-Type' => 'text/html' }
+          )
+        uri = described_class.new(URI('https://lnkd.in/eB25Z2yS'))
+
+        expect(uri.expand).to eq(URI('https://example.com/article'))
+      end
+
+      it 'raises an error if the non-redirect shortener HTML contains no matching element' do
+        stub_request(:get, 'https://lnkd.in/bad')
+          .to_return(status: 200, body: '<html><body><p>No link</p></body></html>')
+        uri = described_class.new(URI('https://lnkd.in/bad'))
+
+        expect { uri.expand }.to raise_error(BadShortenedURI)
+      end
+
       after do
         Configuration.redirects = 5
         Configuration.shorteners.delete('altmetric.it')


### PR DESCRIPTION
Adds support for URL shorteners that do not issue HTTP redirects (e.g. lnkd.in, ebx.sh). These services serve an HTML page containing the destination URL in a known element. Embiggen now handles these by fetching the page and extracting the link via a CSS selector configured per domain in a new non_redirect_shorteners.yml file.

Also fixes three bugs in ShortenerList: a missing require 'set' that causes a NameError on Ruby 3.2+, unescaped dots in domain regexes that could match unintended hostnames, and a double-wrapping bug in the + method that raised a TypeError once Regexp.escape was introduced.