### PR TITLE
Add edge.prnewswire.com to shorteners list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.11.0] - 2026-06-18
+
+### Changed
+
+- Added 1 new shortener (`edge.prnewswire.com`). Not technically a shortener,
+but it does redirect to a different domain and is therefore useful to expand.
+
 ## [1.10.0] - 2026-04-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@
 
 A Ruby library to expand shortened URLs.
 
-**Current version:** 1.10.0  
+**Current version:** 1.11.0
 **Supported Ruby versions:** >= 2.7
 
 ## Installation
 
 ```
-gem install embiggen -v '~> 1.8'
+gem install embiggen -v '~> 1.11'
 ```
 
 Or, in your `Gemfile`:
 
 ```ruby
-gem 'embiggen', '~> 1.8'
+gem 'embiggen', '~> 1.11'
 ```
 
 ## Usage

--- a/embiggen.gemspec
+++ b/embiggen.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'embiggen'
-  s.version = '1.10.0'
+  s.version = '1.11.0'
   s.summary = 'A library to expand shortened URLs'
   s.description = <<-EOF
     A library to expand shortened URIs, respecting timeouts, following

--- a/shorteners.txt
+++ b/shorteners.txt
@@ -2391,6 +2391,7 @@ ed.tips
 edciencia.me
 edcnts.com
 edge.ie
+edge.prnewswire.com
 edhq.co
 edin.ac
 edin.com


### PR DESCRIPTION
Not technically a shortener, but it does redirect to a different domain and is therefore useful to expand

Bump version to 1.11.0